### PR TITLE
Build.gradle: change `compile` statement to `implementation` to fix gradle build issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
     implementation files('libs/login-with-amazon-sdk.jar')
 }
   


### PR DESCRIPTION
The `compile` statement has been deprecated and doesn't work anymore in Gradle 7